### PR TITLE
vcf.split fix

### DIFF
--- a/cre.sh
+++ b/cre.sh
@@ -210,7 +210,6 @@ function f_make_report
 	bcftools view -R ${family}-ensemble.db.txt.positions $fprefix.vcf.gz | bcftools sort | vt decompose -s - | vt uniq - -o $fprefix.subset.vcf.gz
 	tabix $fprefix.subset.vcf.gz
 	f_fix_sample_names $fprefix
-	# for some reason there was vcf.platypus.getNV.gatk3.sh - memory bug
 	vcf.platypus.getNV.sh $fprefix.subset.vcf.gz $reference
     fi
 

--- a/vcf.platypus.getNV.gatk3.sh
+++ b/vcf.platypus.getNV.gatk3.sh
@@ -6,7 +6,7 @@ bname=`basename $1 .subset.vcf.gz`
 
 if [ -e $1 ]
 then
-    gatk3 -Xmx10G -T VariantsToTable \
+    gatk3 -T VariantsToTable \
     -R $2 \
     -V $1 \
     -F CHROM -F POS -F REF -F ALT -F TC -GF NR -GF NV \

--- a/vcf.split_multi.sh
+++ b/vcf.split_multi.sh
@@ -2,7 +2,8 @@
 
 # $1 = family.vcf.gz
 
-for sample in `cat samples.txt`; 
+for sample in `bcftools queru -l $1`
 do 
-    bcftools view -c1 -Ov -s $sample -o $sample.vcf $1;
-done;
+    bcftools view -c1 -Ov -s $sample -o $sample.vcf $1
+done
+

--- a/vcf.split_multi.sh
+++ b/vcf.split_multi.sh
@@ -2,7 +2,7 @@
 
 # $1 = family.vcf.gz
 
-for sample in `bcftools queru -l $1`
+for sample in `bcftools query -l $1`
 do 
     bcftools view -c1 -Ov -s $sample -o $sample.vcf $1
 done


### PR DESCRIPTION
Fix to extract sample vcfs from the family_id.vcf.gz file.
Having '-' causes the vcf.split script to fail, since samples.txt has the corrected sample name (replace '-' with '_').

Fix: query the vcf file for sample names and extract those 